### PR TITLE
Fix wrapping in <button> when created in JS

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,13 @@ require('document-register-element');
 var copy = require('copy-to-clipboard');
 var CopyButtonPrototype = Object.create(HTMLButtonElement.prototype);
 
-function handleCopyClick(e) {
-  var toCopy, toCopyEl;
-  if (toCopy = this.getAttribute('target-text')) {
-    return copy(toCopy);
+function handleCopyClick() {
+  if (this.hasAttribute('target-text')) {
+    return copy(this.getAttribute('target-text'));
   }
-  if (toCopy = this.getAttribute('target-element')) {
-    toCopyEl = document.querySelector(toCopy);
     return copy(toCopyEl.value || toCopyEl.textContent || toCopyEl.innerText || '');
+  if (this.hasAttribute('target-element')) {
+    var toCopyEl = document.querySelector(this.getAttribute('target-element'));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 require('document-register-element');
 var copy = require('copy-to-clipboard');
 var CopyButtonPrototype = Object.create(HTMLButtonElement.prototype);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ require('document-register-element');
 var copy = require('copy-to-clipboard');
 var CopyButtonPrototype = Object.create(HTMLButtonElement.prototype);
 
-function handleCopyClick() {
+function handleCopyClick(event) {
+  if (event.defaultPrevented) return;
   if (this.hasAttribute('target-text')) {
     return copy(this.getAttribute('target-text'));
   }

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ function handleCopyClick() {
   if (this.hasAttribute('target-text')) {
     return copy(this.getAttribute('target-text'));
   }
-    return copy(toCopyEl.value || toCopyEl.textContent || toCopyEl.innerText || '');
   if (this.hasAttribute('target-element')) {
     var toCopyEl = document.querySelector(this.getAttribute('target-element'));
+    return copy(toCopyEl.value || toCopyEl.textContent || '');
   }
 }
 
@@ -21,10 +21,10 @@ CopyButtonPrototype.createdCallback = function() {
       button.appendChild(node);
     }
   } else {
-    button.appendChild(document.createTextNode('Click to copy to clipboard'));
+    button.textContent = 'Click to copy to clipboard';
   }
   this.appendChild(button);
-  this.onclick = handleCopyClick;
+  this.addEventListener('click', handleCopyClick);
 };
 
 var CopyButton = document.registerElement('copy-button', {

--- a/index.js
+++ b/index.js
@@ -33,6 +33,6 @@ CopyButtonPrototype.attachedCallback = function() {
   this.wrappedInButton = true;
 };
 
-var CopyButton = document.registerElement('copy-button', {
+module.exports = document.registerElement('copy-button', {
   prototype: CopyButtonPrototype,
 });

--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ function handleCopyClick() {
 }
 
 CopyButtonPrototype.createdCallback = function() {
+  this.wrappedInButton = false;
+};
+
+CopyButtonPrototype.attachedCallback = function() {
+  if (this.wrappedInButton) return;
   var button = document.createElement('button');
   if (this.childNodes.length) {
     var node;
@@ -25,6 +30,7 @@ CopyButtonPrototype.createdCallback = function() {
   }
   this.appendChild(button);
   this.addEventListener('click', handleCopyClick);
+  this.wrappedInButton = true;
 };
 
 var CopyButton = document.registerElement('copy-button', {


### PR DESCRIPTION
Creating `<copy-button>` in JavaScript like this:

``` js
let btn = document.createElement("copy-button")
btn.textContent = "hello, world"
```

will result in `hello, world` not being wrapped in `<button>`, because wrapping happens on line 1 and created `<button>` gets deleted on line 2.

I would say this PR is breaking (because of `onclick` and IE8 support) and deserves `2.0`.
