### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "prepublish": "npm run build && exit-on-dirty-git",
     "build": "browserify index.js -o bundled.js && uglifyjs bundled.js -o bundled.min.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sudodoki/copy-button.git"
+  },
   "keywords": [
     "clipboard",
     "copy",


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	*copy-button